### PR TITLE
suggest using remotes package rather than devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository hosts the R package `datarobot.pe.clustering`. This package allo
 
 ## Usage
 
-You can install this package using ``devtools::install_github()`` (see below) and then incorporate it into your R scripts, together with the `datarobot` R package and a DataRobot installation.
+You can install this package using ``remotes::install_github()`` (see below) and then incorporate it into your R scripts, together with the `datarobot` R package and a DataRobot installation.
 
 Once installed, view the vignette for further documentation and examples.
 
@@ -19,13 +19,13 @@ This repository contains the package metadata, package code, unit tests, and doc
 The development version here can be downloaded straight from GitHub. Add in the `build_vignettes` flag to ensure the vignettes are built. 
 
 ```R
-if (!require("devtools")) { install.packages("devtools") }
-devtools::install_github("datarobot-community/pe-clustering-R", build_vignettes=TRUE)
+if (!require("remotes")) { install.packages("remotes") }
+remotes::install_github("datarobot-community/pe-clustering-R", build_vignettes=TRUE)
 ```
 
 You will need to [set up a GitHub PAT token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) and then `export GITHUB_PAT=<token>` in your shell before running `install_github`.
 
-To install a particular version from GitHub (or a particular branch), use `@` notation in `install_github`, e.g. `devtools::install_github("datarobot-community/pe-clustering-R@v1.0")` or `devtools::install_github("datarobot-community/pe-clustering-R@myAwesomeBranch")`.
+To install a particular version from GitHub (or a particular branch), use `@` notation in `install_github`, e.g. `remotes::install_github("datarobot-community/pe-clustering-R@v1.0")` or `remotes::install_github("datarobot-community/pe-clustering-R@myAwesomeBranch")`.
 
 
 ## Development and Contributing


### PR DESCRIPTION
In reviewing a community article using this R package, I'd like to suggest that users don't *have* to use the very large devtools package when the smaller remotes package will do just fine.